### PR TITLE
adds loading state when AI result is loading

### DIFF
--- a/src/components/ui/chipified-filters/ChipFilterInput.tsx
+++ b/src/components/ui/chipified-filters/ChipFilterInput.tsx
@@ -1,4 +1,5 @@
 import * as Toolbar from "@radix-ui/react-toolbar";
+import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
@@ -843,11 +844,13 @@ export const ChipFilterInput: React.FC<ChipFilterInputProps> = ({
 						aria-controls="autocomplete-dropdown"
 						aria-expanded={showAutocomplete}
 					/>
-					{isNaturalLanguageMode && (
+					{isParsingNaturalLanguage ? (
+						<Loader2 className="w-4 h-4 text-gray-500 animate-spin ml-2" />
+					) : isNaturalLanguageMode ? (
 						<span className="text-xs text-gray-500 whitespace-nowrap ml-2">
 							Press Enter to build your filter.
 						</span>
-					)}
+					) : null}
 				</div>
 			</fieldset>
 


### PR DESCRIPTION
Adds a loading state while AI result is loaded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays a spinner next to the filter input while AI parsing is in progress, replacing the hint text during that state.
> 
> - **UI (`src/components/ui/chipified-filters/ChipFilterInput.tsx`)**:
>   - Show `Loader2` spinner when `isParsingNaturalLanguage` is true; otherwise show the natural language hint.  
>   - Keeps input disabled during parsing and maintains autocomplete behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09b1e89100b0a281815e0b11dac79192b82d4028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->